### PR TITLE
Run Next.js build and deploy

### DIFF
--- a/templates/v0-clone/app/api/inngest/route.ts
+++ b/templates/v0-clone/app/api/inngest/route.ts
@@ -1,7 +1,7 @@
 import { serve } from "inngest/next";
 import { inngest, runAgent, createSession } from "@/lib/inngest";
 
-export const maxDuration = 800;
+export const maxDuration = 300;
 
 // Create an API that serves zero functions
 export const { GET, POST, PUT } = serve({


### PR DESCRIPTION
## Description
Fixes Vercel deployment error by reducing the `maxDuration` for the `/api/inngest` route from 800 seconds to 300 seconds, aligning with the Vercel Hobby plan limits.

## Related Issue
Fixes #<issue number>