### PR TITLE
Fix Convex deployment address error

### DIFF
--- a/templates/v0-clone/providers/convex-provider.tsx
+++ b/templates/v0-clone/providers/convex-provider.tsx
@@ -3,7 +3,9 @@
 import { ConvexProvider, ConvexReactClient } from "convex/react";
 import { ReactNode } from "react";
 
-const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!);
+const convex = new ConvexReactClient(process.env.NEXT_PUBLIC_CONVEX_URL!, {
+  skipConvexDeploymentUrlCheck: true,
+});
 
 export function ConvexClientProvider({ children }: { children: ReactNode }) {
   return <ConvexProvider client={convex}>{children}</ConvexProvider>;


### PR DESCRIPTION
## Description
Resolves a Convex deployment URL validation error by adding `skipConvexDeploymentUrlCheck: true` to the `ConvexReactClient` configuration. This allows the client to connect to URLs ending with `.convex.site`, which are valid for HTTP Actions.

## Related Issue
Fixes #<issue number>